### PR TITLE
feat: search api 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/search/crawling/controller/SearchController.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/controller/SearchController.kt
@@ -1,0 +1,22 @@
+package com.yourssu.search.crawling.controller
+
+import com.yourssu.search.crawling.dto.SearchListResponse
+import com.yourssu.search.crawling.service.SearchService
+import org.springframework.data.domain.PageRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/search")
+class SearchController(
+    private val searchService: SearchService
+) {
+    @GetMapping
+    fun search(@RequestParam query: String,
+               @RequestParam page: Int): SearchListResponse {
+        val pageable = PageRequest.of(page, 10)
+        return searchService.search(query, pageable)
+    }
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchListResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchListResponse.kt
@@ -1,0 +1,6 @@
+package com.yourssu.search.crawling.dto
+
+data class SearchListResponse(
+    val resultList: List<SearchResponse>
+) {
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
@@ -1,0 +1,23 @@
+package com.yourssu.search.crawling.dto
+
+import com.yourssu.search.crawling.domain.Information
+
+data class SearchResponse(
+    val title: String,
+    val link: String,
+    val content: String,
+    val date: String,
+    val thumbnail: List<String>
+) {
+    companion object {
+        fun of(information: Information): SearchResponse {
+            return SearchResponse(
+                title = information.title,
+                link = information.contentUrl,
+                content = information.content,
+                date = information.date,
+                thumbnail = information.imgList
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
@@ -1,0 +1,20 @@
+package com.yourssu.search.crawling.service
+
+import com.yourssu.search.crawling.repository.InformationRepository
+import com.yourssu.search.crawling.dto.SearchListResponse
+import com.yourssu.search.crawling.dto.SearchResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+
+@Service
+class SearchService(
+    private val informationRepository: InformationRepository
+) {
+    fun search(query: String, pageable: Pageable): SearchListResponse {
+        val informations = informationRepository.findByInfoOrderByScoreDesc(query, pageable).map { SearchResponse.of(it) }.toList()
+
+        return SearchListResponse(
+            resultList = informations
+        )
+    }
+}


### PR DESCRIPTION
## Key Changes
- 검색 api를 구현하였습니다.
- `ex. GET /search?query=숭실대학교&page=1`
```
{
    "resultList": [
        {
            "title": "숭실대학교 학칙 개정 사전공고",
            "link": "https://scatch.ssu.ac.kr/%ea%b3%b5%ec%a7%80%ec%82%ac%ed%95%ad/?f&category&paged=239&slug=%EC%88%AD%EC%8B%A4%EB%8C%80%ED%95%99%EA%B5%90-%ED%95%99%EC%B9%99-%EA%B0%9C%EC%A0%95-%EC%82%AC%EC%A0%84%EA%B3%B5%EA%B3%A0-25&keyword",
            "content": "",
            "date": "2021.05.12",
            "thumbnail": [
                "https://scatch.ssu.ac.kr/wp-content/uploads/sites/5/2021/05/학칙개정.png"
            ]
        },
        {
            "title": "[숭실대학교 상담센터] 연구교수 채용공고",
            "link": "https://scatch.ssu.ac.kr/%ea%b3%b5%ec%a7%80%ec%82%ac%ed%95%ad/?f&category&paged=214&slug=%EC%88%AD%EC%8B%A4%EB%8C%80%ED%95%99%EA%B5%90-%EC%83%81%EB%8B%B4%EC%84%BC%ED%84%B0-%EC%97%B0%EA%B5%AC%EA%B5%90%EC%88%98-%EC%B1%84%EC%9A%A9%EA%B3%B5%EA%B3%A0&keyword",
            "content": "2021 숭실대 상담센터 연구교수 채용공고\n• 상담심리 전문가\n• 본교 건학이념에 부합하는 기독교인\n(학생상담, 상담교육, 상담 연구 및 프로그램 개발, 상담코칭 및 컨설팅, 실태조사 및 상담성과연구 등)\n• 외국어 상담 가능자(중국어 또는 영어)\n• 개인정보수집 및 활용 동의서(본교양식) 1부\n• 기독교 교인증명서 또는 세례증명서 사본 1부\n• 학사학위 이상 모든 졸업증명서 사본 1부(1개의 PDF파일로 병합하여 제출)\n• 경력증명서 사본 1부(1개의 PDF파일로 병합하여 제출)\n• 상담 관련 자격증 사본 1부\n• 기타 관련 자격증 사본 1부(해당자에 한함)\n• 제출서류 원본을 스캔(PDF 또는 JPG파일)하여 메일로 제출\n• 이메일 제목은 ‘2021년 9월 상담센터 연구교수 지원(지원자 성명)’으로 기재\n※ 마감시간 전에 이메일 제출 완료되어야 함. 판독 어려울 경우 무효처리함\n(재임용은 계약 사항에 따름)\n• 근무시간 : 주 5일(월~금) 9시~17시 30분(방학 중 단축근무)\n• 급여조건 : 본교 연구교수 처우 기준에 준함\n• 적격자가 없을 경우 채용을 보류할 수 있음\n• 합격자 및 전형 관련사항은 개별통지 예정\n• 제출서류는 반환하지 않음",
            "date": "2021.08.19",
            "thumbnail": []
        }
    ]
}
```