### PR TITLE
Feat: 실시간 검색어 api 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,10 @@ dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")
+
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
+    implementation("ch.qos.logback:logback-classic:1.3.7")
+    implementation("ch.qos.logback:logback-core:1.3.7")
 }
 
 tasks.withType<KotlinCompile> {

--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -1,0 +1,2 @@
+http.host: "0.0.0.0"
+xpack.monitoring.enabled: false

--- a/logstash/config/pipelines.yml
+++ b/logstash/config/pipelines.yml
@@ -1,0 +1,2 @@
+- pipeline.id: spring-boot-logs
+  path.config: "/usr/share/logstash/pipeline/spring-boot-logs.conf"

--- a/logstash/pipeline/spring-boot-logs.conf
+++ b/logstash/pipeline/spring-boot-logs.conf
@@ -1,0 +1,13 @@
+input{
+tcp {
+    port => 5000
+    codec => json_lines }
+}
+output {
+    elasticsearch {
+        hosts => "${ES_CONTAINER_NAME}:9200"
+        index => "logstash-%{+YYYY-MM-dd}"
+        user => ${ES_ID}
+        password => ${ES_PASSWORD}
+    }
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/controller/SearchController.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/controller/SearchController.kt
@@ -1,7 +1,11 @@
 package com.yourssu.search.crawling.controller
 
 import com.yourssu.search.crawling.dto.SearchListResponse
+import com.yourssu.search.crawling.dto.SearchTopQuerysResponse
 import com.yourssu.search.crawling.service.SearchService
+import net.logstash.logback.marker.Markers.append
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,10 +17,18 @@ import org.springframework.web.bind.annotation.RestController
 class SearchController(
     private val searchService: SearchService
 ) {
+    private val logger: Logger = LoggerFactory.getLogger(SearchController::class.java)
+
     @GetMapping
     fun search(@RequestParam query: String,
                @RequestParam page: Int): SearchListResponse {
+        logger.info(append("query", query), "requestURI=/search, query={}", query)
         val pageable = PageRequest.of(page, 10)
         return searchService.search(query, pageable)
+    }
+
+    @GetMapping("/topQuerys")
+    fun getTopKeywords(): SearchTopQuerysResponse {
+        return searchService.searchTopQuerys()
     }
 }

--- a/src/main/kotlin/com/yourssu/search/crawling/domain/AccessLog.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/domain/AccessLog.kt
@@ -1,0 +1,16 @@
+package com.yourssu.search.crawling.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.elasticsearch.annotations.Document
+import org.springframework.data.elasticsearch.annotations.Field
+
+@Document(indexName = "logstash-#{T(java.time.LocalDate).now().toString()}")
+class AccessLog(
+    @field:Id
+    val id: String,
+    val query: String? = null,
+    val message: String,
+    @Field(name = "_@timestamp")
+    val timestamp: String? = null
+) {
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/QueryCountResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/QueryCountResponse.kt
@@ -1,0 +1,7 @@
+package com.yourssu.search.crawling.dto
+
+data class QueryCountResponse(
+    val query: String,
+    val count: Long
+) {
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
@@ -3,6 +3,7 @@ package com.yourssu.search.crawling.dto
 import com.yourssu.search.crawling.domain.Information
 
 data class SearchResponse(
+    val id: String?,
     val title: String,
     val link: String,
     val content: String,
@@ -12,6 +13,7 @@ data class SearchResponse(
     companion object {
         fun of(information: Information): SearchResponse {
             return SearchResponse(
+                id = information.id,
                 title = information.title,
                 link = information.contentUrl,
                 content = information.content,

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchTopQuerysResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchTopQuerysResponse.kt
@@ -1,0 +1,7 @@
+package com.yourssu.search.crawling.dto
+
+data class SearchTopQuerysResponse(
+    val basedTime: String,
+    val querys: List<QueryCountResponse>
+) {
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/repository/AccessLogNativeQueryRepository.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/repository/AccessLogNativeQueryRepository.kt
@@ -1,0 +1,70 @@
+package com.yourssu.search.crawling.repository
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders
+import co.elastic.clients.json.JsonData
+import com.yourssu.search.crawling.domain.AccessLog
+import com.yourssu.search.crawling.dto.QueryCountResponse
+import com.yourssu.search.crawling.dto.SearchTopQuerysResponse
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations
+import org.springframework.data.elasticsearch.client.elc.NativeQuery
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@Component
+class AccessLogNativeQueryRepository (
+    private val elasticsearchOperations: ElasticsearchOperations
+) {
+    fun findTopQuerys(): SearchTopQuerysResponse {
+        // 전날 00:00 - 24:00까지 집계 (UTC 기준)
+        val now = LocalDateTime.of(LocalDate.now(), LocalTime.of(15, 0, 0)).minusDays(1)
+        val dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+        val startTime = now.minusDays(1).format(dtf)
+        val endTime = now.format(dtf)
+
+        val rangeQuery = createRangeQuery("@timestamp", startTime, endTime)
+        val matchPhraseQuery = createMatchPhraseQuery("message", "requestURI=/search, query=")
+        val aggregation = createAggregation("query.keyword", 10)
+
+        val nativeQuery = NativeQuery.builder()
+            .withQuery(QueryBuilders.bool().must(rangeQuery, matchPhraseQuery).build()._toQuery())
+            .withAggregation("top_keywords", aggregation)
+            .build()
+
+        val searchHits = elasticsearchOperations.search(nativeQuery, AccessLog::class.java)
+
+        val querys = if (searchHits.aggregations is ElasticsearchAggregations) {
+            val buckets = (searchHits.aggregations as ElasticsearchAggregations)
+                .aggregationsAsMap()["top_keywords"]!!.aggregation().aggregate.sterms().buckets().array()
+            buckets.map { QueryCountResponse(it.key().stringValue(), it.docCount()) }
+        } else {
+            emptyList()
+        }
+
+        return SearchTopQuerysResponse(startTime, querys)
+    }
+
+    private fun createRangeQuery(field: String, gte: String, lt: String): Query {
+        return QueryBuilders.range().field(field)
+            .gte(JsonData.of(gte))
+            .lt(JsonData.of(lt)).build()._toQuery()
+    }
+
+    private fun createMatchPhraseQuery(field: String, query: String): Query {
+        return QueryBuilders.matchPhrase().field(field)
+            .query(query).build()._toQuery()
+    }
+
+    private fun createAggregation(field: String, size: Int): Aggregation {
+        return AggregationBuilders.terms()
+            .field(field)
+            .size(size)
+            .build()._toAggregation()
+    }
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
@@ -3,12 +3,15 @@ package com.yourssu.search.crawling.service
 import com.yourssu.search.crawling.repository.InformationRepository
 import com.yourssu.search.crawling.dto.SearchListResponse
 import com.yourssu.search.crawling.dto.SearchResponse
+import com.yourssu.search.crawling.dto.SearchTopQuerysResponse
+import com.yourssu.search.crawling.repository.AccessLogNativeQueryRepository
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 
 @Service
 class SearchService(
-    private val informationRepository: InformationRepository
+    private val informationRepository: InformationRepository,
+    private val accessLogNativeQueryRepository: AccessLogNativeQueryRepository
 ) {
     fun search(query: String, pageable: Pageable): SearchListResponse {
         val informations = informationRepository.findByInfoOrderByScoreDesc(query, pageable).map { SearchResponse.of(it) }.toList()
@@ -16,5 +19,9 @@ class SearchService(
             resultCount = informations.size,
             resultList = informations
         )
+    }
+
+    fun searchTopQuerys(): SearchTopQuerysResponse {
+        return accessLogNativeQueryRepository.findTopQuerys()
     }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Console -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{10} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Logstash -->
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_HOST}</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <timestampPattern>yyyy-MM-dd HH:mm:ss</timestampPattern>
+            <timeZone>Asia/Seoul</timeZone>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE" />
+    </root>
+    <logger name="com.yourssu.search.crawling.controller.SearchController" level="info">
+        <appender-ref ref="LOGSTASH" />
+    </logger>
+    <logger name="com.yourssu.search.crawling.service.SearchService" level="info">
+        <appender-ref ref="LOGSTASH" />
+    </logger>
+</configuration>


### PR DESCRIPTION
## Key Changes
- Logback + Logstash + Elasticsearch를 이용하여 액세스 로그 수집
- 검색 시점, 전날 00:00 - 24:00 기준 검색 횟수 순으로 조회
- 10개씩 집계
- ex. ` GET /search/topQuerys `
```
{
    "basedTime": "2024-02-16T15:00:00",
    "querys": [
        {
            "query": "멘토 ",
            "count": 4
        },
        {
            "query": "멘토 모집",
            "count": 3
        }
    ]
}
```