### PR TITLE
fix: favicon, 문서 출처 필드 추가

### DIFF
--- a/src/main/kotlin/com/yourssu/search/crawling/domain/Information.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/domain/Information.kt
@@ -12,4 +12,6 @@ class Information(
     val date: String,
     var contentUrl: String,
     var imgList: List<String>,
+    var favicon: String?,
+    var source: String
 )

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
@@ -10,6 +10,8 @@ data class SearchResponse(
     val date: String,
     val thumbnailCount: Int,
     val thumbnail: List<String>,
+    val favicon: String?,
+    val source: String
 ) {
     companion object {
         fun of(information: Information): SearchResponse {
@@ -21,6 +23,8 @@ data class SearchResponse(
                 date = information.date,
                 thumbnailCount = information.imgList.size,
                 thumbnail = information.imgList,
+                favicon = information.favicon,
+                source = information.source
             )
         }
     }

--- a/src/main/kotlin/com/yourssu/search/crawling/service/CrawlingService.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/service/CrawlingService.kt
@@ -26,6 +26,11 @@ class CrawlingService(
     private var noticeEndNumber = 638
     private var funEndNumber = 285
 
+    companion object {
+        const val SOURCE_NAME_NOTICE = "공지사항"
+        const val SOURCE_NAME_FUN = "펀시스템"
+    }
+
     suspend fun crawlingNotice() {
         withContext(Dispatchers.IO) {
             informationRepository.deleteAll()
@@ -39,6 +44,7 @@ class CrawlingService(
             ".notice_col3 a",
             ".notice_col1 .text-info",
             noticeEndNumber,
+            SOURCE_NAME_NOTICE
         )
     }
 
@@ -55,6 +61,7 @@ class CrawlingService(
             "a",
             "small.thema_point_color.topic ~ small time",
             funEndNumber,
+            SOURCE_NAME_FUN
         )
     }
 
@@ -66,6 +73,7 @@ class CrawlingService(
         urlSelector: String,
         dateSelector: String,
         endNumber: Int,
+        source: String
     ) {
         val jobs = mutableListOf<Deferred<Unit>>()
         val coroutineScope = CoroutineScope(Dispatchers.IO)
@@ -76,7 +84,7 @@ class CrawlingService(
                     val document = Jsoup.connect("$baseUrl/$pageNumber")
                         .userAgent(userAgent)
                         .get()
-                    val pageTitle = document.title()
+
                     val ul = document.select(ulSelector)
 
                     var faviconElement: Element? = document.head()
@@ -117,7 +125,7 @@ class CrawlingService(
                                 contentUrl = contentUrl,
                                 imgList = imgList,
                                 favicon = faviconUrl,
-                                source = pageTitle
+                                source = source
                             ),
                         )
                     }


### PR DESCRIPTION
- favicon, 문서 출처 필드를 추가했습니다.
- 문서 출처(source)는 이전 회의(https://www.notion.so/yourssu/Soomsil-V2-TF-8-96b9ce80af2244efaca34536476012ef?pvs=4 )에서 언급된대로 간단하게 표현되었습니다.