### PR TITLE
Feat: 실시간 랭킹 반영 검색어에서 빈 문자열 제거

### DIFF
--- a/src/main/kotlin/com/yourssu/search/crawling/controller/SearchController.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/controller/SearchController.kt
@@ -1,7 +1,7 @@
 package com.yourssu.search.crawling.controller
 
 import com.yourssu.search.crawling.dto.SearchListResponse
-import com.yourssu.search.crawling.dto.SearchTopQuerysResponse
+import com.yourssu.search.crawling.dto.SearchTopQueriesResponse
 import com.yourssu.search.crawling.service.SearchService
 import net.logstash.logback.marker.Markers.append
 import org.slf4j.Logger
@@ -27,8 +27,8 @@ class SearchController(
         return searchService.search(query, pageable)
     }
 
-    @GetMapping("/topQuerys")
-    fun getTopKeywords(): SearchTopQuerysResponse {
-        return searchService.searchTopQuerys()
+    @GetMapping("/topQueries")
+    fun getTopKeywords(): SearchTopQueriesResponse {
+        return searchService.searchTopQueries()
     }
 }

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchTopQueriesResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchTopQueriesResponse.kt
@@ -1,0 +1,7 @@
+package com.yourssu.search.crawling.dto
+
+data class SearchTopQueriesResponse(
+    val basedTime: String,
+    val queries: List<QueryCountResponse>
+) {
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchTopQuerysResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchTopQuerysResponse.kt
@@ -1,7 +1,0 @@
-package com.yourssu.search.crawling.dto
-
-data class SearchTopQuerysResponse(
-    val basedTime: String,
-    val querys: List<QueryCountResponse>
-) {
-}

--- a/src/main/kotlin/com/yourssu/search/crawling/repository/AccessLogNativeQueryRepository.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/repository/AccessLogNativeQueryRepository.kt
@@ -7,7 +7,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders
 import co.elastic.clients.json.JsonData
 import com.yourssu.search.crawling.domain.AccessLog
 import com.yourssu.search.crawling.dto.QueryCountResponse
-import com.yourssu.search.crawling.dto.SearchTopQuerysResponse
+import com.yourssu.search.crawling.dto.SearchTopQueriesResponse
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations
 import org.springframework.data.elasticsearch.client.elc.NativeQuery
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations
@@ -21,7 +21,7 @@ import java.time.format.DateTimeFormatter
 class AccessLogNativeQueryRepository (
     private val elasticsearchOperations: ElasticsearchOperations
 ) {
-    fun findTopQuerys(): SearchTopQuerysResponse {
+    fun findTopQueries(): SearchTopQueriesResponse {
         // 전날 00:00 - 24:00까지 집계 (UTC 기준)
         val now = LocalDateTime.of(LocalDate.now(), LocalTime.of(15, 0, 0)).minusDays(1)
         val dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
@@ -51,7 +51,7 @@ class AccessLogNativeQueryRepository (
             emptyList()
         }
 
-        return SearchTopQuerysResponse(basedTime, querys)
+        return SearchTopQueriesResponse(basedTime, querys)
     }
 
     private fun createRangeQuery(field: String, gte: String, lt: String): Query {

--- a/src/main/kotlin/com/yourssu/search/crawling/repository/AccessLogNativeQueryRepository.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/repository/AccessLogNativeQueryRepository.kt
@@ -31,10 +31,13 @@ class AccessLogNativeQueryRepository (
 
         val rangeQuery = createRangeQuery("@timestamp", startTime, endTime)
         val matchPhraseQuery = createMatchPhraseQuery("message", "requestURI=/search, query=")
+        val matchQuery = createMatchQuery("query.keyword", "")
         val aggregation = createAggregation("query.keyword", 10)
 
+        val boolQuery = QueryBuilders.bool().must(rangeQuery, matchPhraseQuery).mustNot(matchQuery).build()._toQuery()
+
         val nativeQuery = NativeQuery.builder()
-            .withQuery(QueryBuilders.bool().must(rangeQuery, matchPhraseQuery).build()._toQuery())
+            .withQuery(boolQuery)
             .withAggregation("top_keywords", aggregation)
             .build()
 
@@ -59,6 +62,11 @@ class AccessLogNativeQueryRepository (
 
     private fun createMatchPhraseQuery(field: String, query: String): Query {
         return QueryBuilders.matchPhrase().field(field)
+            .query(query).build()._toQuery()
+    }
+
+    private fun createMatchQuery(field: String, query: String): Query {
+        return QueryBuilders.match().field(field)
             .query(query).build()._toQuery()
     }
 

--- a/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
@@ -2,7 +2,7 @@ package com.yourssu.search.crawling.service
 
 import com.yourssu.search.crawling.dto.SearchListResponse
 import com.yourssu.search.crawling.dto.SearchResponse
-import com.yourssu.search.crawling.dto.SearchTopQuerysResponse
+import com.yourssu.search.crawling.dto.SearchTopQueriesResponse
 import com.yourssu.search.crawling.repository.AccessLogNativeQueryRepository
 import com.yourssu.search.crawling.repository.InformationRepository
 import org.springframework.data.domain.Pageable
@@ -26,7 +26,7 @@ class SearchService(
         )
     }
 
-    fun searchTopQuerys(): SearchTopQuerysResponse {
-        return accessLogNativeQueryRepository.findTopQuerys()
+    fun searchTopQueries(): SearchTopQueriesResponse {
+        return accessLogNativeQueryRepository.findTopQueries()
     }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -22,7 +22,4 @@
     <logger name="com.yourssu.search.crawling.controller.SearchController" level="info">
         <appender-ref ref="LOGSTASH" />
     </logger>
-    <logger name="com.yourssu.search.crawling.service.CrawlingService" level="info">
-        <appender-ref ref="LOGSTASH" />
-    </logger>
 </configuration>


### PR DESCRIPTION
## Key changes
- 문제 상황 : 실시간 랭킹에 반영되는 검색어 중에 빈 문자열도 포함됩니다.
- 문제 해결 :
  - `query가 ""`인 검색 조건을 포함하지 않는 도큐먼트를 가져오도록 must_not 쿼리를 사용하여 해결하였습니다.
- 로그 출력 대상에서 CrawlingService를 제외하였습니다.
- querys -> queries 문법 오류 수정하였습니다.