### PR TITLE
Feat: 검색 쿼리 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/search/crawling/repository/InformationCustomRepository.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/repository/InformationCustomRepository.kt
@@ -1,0 +1,50 @@
+package com.yourssu.search.crawling.repository
+
+import co.elastic.clients.elasticsearch._types.query_dsl.*
+import co.elastic.clients.elasticsearch._types.query_dsl.FieldValueFactorModifier.Log1p
+import com.yourssu.search.crawling.domain.Information
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.elasticsearch.client.elc.NativeQuery
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations
+import org.springframework.stereotype.Component
+
+@Component
+class InformationCustomRepository (
+    private val elasticsearchOperations: ElasticsearchOperations
+) {
+    fun search(query: String, pageable: Pageable): Page<Information> {
+        val multiMatch = MultiMatchQuery.Builder()
+            .query(query)
+            .fields(listOf("title", "content"))
+            .build()
+
+        val fieldValueFactor = FieldValueFactorScoreFunction.Builder()
+            .field("date")
+            .factor(0.5)
+            .missing(0.0)
+            .modifier(Log1p)
+            .build()
+
+        val functionScore = FunctionScore.Builder()
+            .fieldValueFactor(fieldValueFactor)
+            .build()
+
+        val functionScoreQuery = FunctionScoreQuery.Builder()
+            .query(multiMatch._toQuery())
+            .functions(listOf(functionScore))
+            .boostMode(FunctionBoostMode.Sum)
+            .scoreMode(FunctionScoreMode.Sum)
+            .build()
+
+        val nativeQuery = NativeQuery.builder()
+            .withQuery(functionScoreQuery._toQuery())
+            .withPageable(pageable)
+            .build()
+
+        val searchHits = elasticsearchOperations.search(nativeQuery, Information::class.java)
+        val content = searchHits.searchHits.map { it.content }
+        return PageImpl(content, pageable, searchHits.totalHits)
+    }
+}

--- a/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
@@ -6,6 +6,7 @@ import com.yourssu.search.crawling.dto.SearchResponse
 import com.yourssu.search.crawling.dto.SearchTopQueriesResponse
 import com.yourssu.search.crawling.dto.request.SaveInformationRequest
 import com.yourssu.search.crawling.repository.AccessLogNativeQueryRepository
+import com.yourssu.search.crawling.repository.InformationCustomRepository
 import com.yourssu.search.crawling.repository.InformationRepository
 import com.yourssu.search.global.exception.ElasticConnectionException
 import org.springframework.data.domain.Pageable
@@ -14,13 +15,14 @@ import org.springframework.stereotype.Service
 @Service
 class SearchService(
     private val informationRepository: InformationRepository,
-    private val accessLogNativeQueryRepository: AccessLogNativeQueryRepository
+    private val accessLogNativeQueryRepository: AccessLogNativeQueryRepository,
+    private val customInformationRepository: InformationCustomRepository
 ) {
     fun search(
         query: String,
         pageable: Pageable
     ): SearchListResponse {
-        val result = informationRepository.findByInfoOrderByScoreDesc(query, pageable)
+        val result = customInformationRepository.search(query, pageable)
         val informations = result.map { SearchResponse.of(it) }.toList()
         return SearchListResponse(
             totalCount = result.totalElements,


### PR DESCRIPTION
## 작업 내용
- 검색 쿼리 변경
1. 질의어를 `제목` 또는 `내용` 필드를 기준으로 검색합니다.
2. 관련성을 의미하는 `_score` 외 `date 기준 내림차순 정렬`도 최종 점수 계산에 반영합니다.
```
// 쿼리 해석
POST /information/_search
{
  "query": {
    "function_score": {
      "query": {
        "multi_match": {
          "query": "소프트웨어 공모전",
          "fields": ["title", "content"]
        }
      },
      "functions": [
        {
          "field_value_factor": { // date 값만을 이용하여 추가적인 스코어 계산
            "field": "date",
            "factor": 0.5, // date와 곱해질 요소
            "modifier": "log1p", // date에 적용될 제어자
            "missing": 0 // date 값이 없을 경우 들어갈 기본값
          }
        }
      ],
      "boost_mode": "sum", // score_mode로 계산된 스코어와 쿼리의 스코어가 결합되는 방법
      "score_mode": "sum" // functions 안에서 정의된 각 function(조건)의 스코어가 결합되는 방법
    }
  },
  "size": 10
}
```