### PR TITLE
Feat: information 인덱스 date 필드 타입 변경

### DIFF
--- a/src/main/kotlin/com/yourssu/search/crawling/domain/Information.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/domain/Information.kt
@@ -2,6 +2,9 @@ package com.yourssu.search.crawling.domain
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.elasticsearch.annotations.Document
+import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.FieldType
+import java.time.LocalDate
 
 @Document(indexName = "information")
 class Information(
@@ -9,7 +12,8 @@ class Information(
     val id: String? = null,
     var title: String,
     var content: String,
-    val date: String,
+    @Field(type = FieldType.Date, format = [], pattern = ["yyyy.MM.dd"])
+    val date: LocalDate,
     var contentUrl: String,
     var imgList: List<String>,
     var favicon: String?,

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
@@ -1,7 +1,6 @@
 package com.yourssu.search.crawling.dto
 
 import com.yourssu.search.crawling.domain.Information
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 data class SearchResponse(

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/SearchResponse.kt
@@ -1,6 +1,8 @@
 package com.yourssu.search.crawling.dto
 
 import com.yourssu.search.crawling.domain.Information
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 data class SearchResponse(
     val id: String?,
@@ -15,12 +17,14 @@ data class SearchResponse(
 ) {
     companion object {
         fun of(information: Information): SearchResponse {
+            val dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
             return SearchResponse(
                 id = information.id,
                 title = information.title,
                 link = information.contentUrl,
                 content = information.content,
-                date = information.date,
+                date = information.date.format(dateFormatter),
                 thumbnailCount = information.imgList.size,
                 thumbnail = information.imgList,
                 favicon = information.favicon,

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/request/SaveInformationRequest.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/request/SaveInformationRequest.kt
@@ -1,13 +1,14 @@
 package com.yourssu.search.crawling.dto.request
 
 import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
 
 class SaveInformationRequest(
     @field:NotNull
     val id: String,
     val title: String,
     val content: String,
-    val date: String,
+    val date: LocalDate,
     val contentUrl: String,
     val imgList: List<String>,
     val favicon: String?,

--- a/src/main/kotlin/com/yourssu/search/crawling/dto/request/UpdateInformationRequest.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/dto/request/UpdateInformationRequest.kt
@@ -1,13 +1,14 @@
 package com.yourssu.search.crawling.dto.request
 
 import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
 
 class UpdateInformationRequest(
     @field:NotNull
     val id: String,
     val title: String,
     val content: String,
-    val date: String,
+    val date: LocalDate,
     val contentUrl: String,
     val imgList: List<String>,
     val favicon: String?,

--- a/src/main/kotlin/com/yourssu/search/crawling/service/CrawlingService.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/service/CrawlingService.kt
@@ -13,6 +13,8 @@ import org.jsoup.select.Elements
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.util.regex.Pattern
 
 @Service
 class CrawlingService(
@@ -103,7 +105,7 @@ class CrawlingService(
                     }
 
                     ul.forEach {
-                        val date = it.selectFirst(dateSelector)?.text() ?: ""
+                        val rawDate = it.selectFirst(dateSelector)?.text() ?: ""
                         val title = it.selectFirst(titleSelector)?.text() ?: ""
                         val contentUrl = it.selectFirst(urlSelector)?.attr("abs:href") ?: ""
                         val paragraphs = Jsoup.connect(contentUrl).get().select(contentSelector)
@@ -118,17 +120,22 @@ class CrawlingService(
                             }
                         }
 
-                        informationRepository.save(
-                            Information(
-                                title = title,
-                                content = content.toString().trim(),
-                                date = date,
-                                contentUrl = contentUrl,
-                                imgList = imgList,
-                                favicon = faviconUrl,
-                                source = source
+                        val extractedDate = extractDate(rawDate)
+                        if (extractedDate != null) {
+                            informationRepository.save(
+                                Information(
+                                    title = title,
+                                    content = content.toString().trim(),
+                                    date = extractedDate,
+                                    contentUrl = contentUrl,
+                                    imgList = imgList,
+                                    favicon = faviconUrl,
+                                    source = source
+                                )
                             )
-                        )
+                        } else {
+                            log.error("날짜 추출 실패 : $rawDate")
+                        }
                     }
                 }
             jobs.add(deferredJob)
@@ -136,6 +143,25 @@ class CrawlingService(
 
         coroutineScope.async {
             jobs.awaitAll()
+        }
+    }
+
+    private fun extractDate(dateStr: String): LocalDate? {
+        val datePattern = Pattern.compile("(\\d{4})\\.(\\d{2})\\.(\\d{2})")
+        val matcher = datePattern.matcher(dateStr)
+
+        return if (matcher.find()) {
+            val year = matcher.group(1).toInt()
+            val month = matcher.group(2).toInt()
+            val day = matcher.group(3).toInt()
+
+            try {
+                LocalDate.of(year, month, day)
+            } catch (e: Exception) {
+                null // 날짜 변환 실패 시 null 반환
+            }
+        } else {
+            null // 정규표현식에 맞지 않으면 null 반환
         }
     }
 

--- a/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
+++ b/src/main/kotlin/com/yourssu/search/crawling/service/SearchService.kt
@@ -11,6 +11,7 @@ import com.yourssu.search.crawling.repository.InformationRepository
 import com.yourssu.search.global.exception.ElasticConnectionException
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class SearchService(
@@ -39,7 +40,7 @@ class SearchService(
         id: String,
         title: String,
         content: String,
-        date: String,
+        date: LocalDate,
         contentUrl: String,
         imgList: List<String>,
         favicon: String?,
@@ -84,7 +85,7 @@ class SearchService(
         id: String,
         title: String,
         content: String,
-        date: String,
+        date: LocalDate,
         contentUrl: String,
         imgList: List<String>,
         favicon: String?,


### PR DESCRIPTION
## Key Changes
- 크롤링한 날짜가 `yyyy.MM.dd` 형식을 포함한다는 전제하에, 정규표현식을 사용하여 `yyyy.MM.dd` 형식의 LocalDate로 변환하였습니다.
- information 인덱스의 date 필드 타입을 `String -> LocalDate`로 변경하였습니다.
- 클라이언트의 요청 응답 시에도 date 형식을 `yyyy.MM.dd`로 통일하였습니다. 기존에는 크롤링한 원본 날짜 형식`(yyyy.MM.dd || yyyy.MM.dd(E) || yyyy.MM.dd(E) HH:mm)` 그대로 넘겨줍니다. 하지만 화면 상 표시되는 날짜 형식은 `yyyy.MM.dd`으로 일정하므로 이것에 맞추었습니다. ~~(이 부분 관련해서는 프론트단에 말씀드려야 할 것 같아요)~~

![image](https://github.com/user-attachments/assets/50efe2bd-ebf2-4508-a84f-dd1cab87fc7e)
